### PR TITLE
Remove entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,3 @@ COPY --from=0 /go/build/svc svc
 COPY --from=0 /go/passwd /etc/passwd
 USER 65534
 EXPOSE 8080
-ENTRYPOINT [ "/svc" ]


### PR DESCRIPTION
It is not needed as we will create a new shell within the container of the cronjob.