### PR TITLE
Add coreutils to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ENV GOOS=linux
 RUN go build -ldflags "-extldflags -static" -o backup-svc .
 
 FROM alpine:3.14.1
-RUN apk add --no-cache postgresql-client mongodb-tools
+RUN apk add --no-cache postgresql-client mongodb-tools coreutils
 COPY --from=0 go/backup-svc /usr/local/bin/
 USER 65534


### PR DESCRIPTION
This is needed to get the date conversions correct as relative dates like "yesterday" is not implemented in the base date function.