### PR TITLE
bump version & publish dockerhub & github registry #none

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!-- Lines like this one are comments and will not be shown in the final output. -->
+<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
+<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
+
+<!-- IMPORTANT -->
+<!-- This will bump the patch number on each PR merge unless the title contains #none. -->
+<!-- In order to bump the major or minor version add #major or #minor to the PR title. -->
+
+
+### Describe the pull request:
+<!-- Replace [ ] with [x] to select options. -->
+- [ ] Bug fix
+- [ ] Functional change
+- [ ] New feature
+- [ ] Code cleanup
+- [ ] Build system change
+- [ ] Documentation change
+- [ ] Language translation
+
+### Pull request long description:
+<!-- Describe your pull request in detail. -->
+
+### Changes made:
+<!-- Enumerate the changes with 1), 2), 3) etc. -->
+<!-- Ensure the test cases are updated if needed. -->
+
+<!-- For database schema changes, be extra mindful that any changes done in -->
+<!-- the base schema setup is reflected in the changs performed by migrations  -->
+<!-- scripts -->
+
+### Related issues:
+<!-- Reference issues with #<issue-num>. -->
+<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
+
+### Additional information:
+<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
+
+### Release note:
+<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
+<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
+
+### Documentation change:
+<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
+<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
+<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
+
+### Mentions:
+<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

--- a/.github/workflows/tag_and_build.yaml
+++ b/.github/workflows/tag_and_build.yaml
@@ -1,0 +1,63 @@
+name: Bump version
+on:
+  push:
+    branches:
+    - master
+jobs:
+  tag:
+    name: bump tags
+    outputs:
+      part: ${{ steps.bump_tag.outputs.part }}
+      tag: ${{ steps.bump_tag.outputs.tag }}
+      new_tag: ${{ steps.bump_tag.outputs.new_tag }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '1'
+    - name: Bump version and push tag
+      id: bump_tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch
+
+  push_to_registry:
+    needs: tag
+    if: needs.tag.outputs.part != ''
+    name: Push Docker image to Github Container registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ needs.tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
This will bump the patch number on each PR merge unless the message contains #none.
In order to bump the major or minor version add #major or #minor to the PR message.

#major -> v1.2.3 > 2.0.0
#minor -> v1.2.3 > 1.3.0

If a new tag is created the second part of the action will build an docker image and publish it to the GithHub Container Registry.
The new image can the be pulled by calling docker pull ghcr.io/neicnordic/sda-download:latest