### PR TITLE
[Feature] pg backup integrity

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        test: [db_test, es_test, mongo_test]
+        test: [db_test, es_test, mongo_test, db_integrity_test]
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ s3cmd -c PATH_TO_S3CONF_FILE ls s3://BUCKET-NAME/*INDEX-NAME
 docker container run --rm -i --name pg-backup --network=host $(docker build -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_basebackup
 ```
 
+**NOTE**
+
+This type of backup runs through a docker container because of some compatibility issues
+that might appear between the PostgreSQL 13 running in the `db` container and the local one.
+
 ### Restoring up a database
 
 #### Restore dump file
@@ -88,6 +93,10 @@ docker container run --rm -i --name pg-backup --network=host $(docker build -f d
 ```cmd
 docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name TAR-FILE
 ```
+
+**NOTE**
+
+Again here a docker container is used for the same reason explained in the `Pg_basebackup` section.
 
 ## MongoDB
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This is done in more stages.
 
 * Create a docker volume for the physical copy.
 
-* Get the physical copy form the S3 and unpack it in the docker volume which has been created in the previous step
+* Get the physical copy from the S3 and unpack it in the docker volume which was created in the previous step
 ```cmd
 docker container run --rm -i --name pg-backup --network=host -v <docker-volume>:/home $(docker build -f dev_tools/Dockerfile-backup -q -t backup .) /bin/sda-backup --action pg_db-unpack --name TAR-FILE
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker container run --rm -i --name pg-backup --network=host $(docker build -f d
 
 ### Restoring up a database
 
-#### Restare dump file
+#### Restore dump file
 
 * The target database must exist when restoring the data.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ that might appear between the PostgreSQL 13 running in the `db` container and th
 
 
 ```cmd
-docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name TAR-FILE
+docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_db-unpack --name TAR-FILE
 ```
 
 **NOTE**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go build -ldflags "-extldflags -static" -o backup-svc .
 The specific config file to be used can be set via the environmental variable `CONFIGFILE`,
 which holds the full path to the config file.
 
-All parts of the config file can be set as ENVs where the separator is `_` i.e. the S3 accesskey can be set as `S3_ACCESSKEY`.  
+All parts of the config file can be set as ENVs where the separator is `_` i.e. the S3 accesskey can be set as `S3_ACCESSKEY`.
 ENVs will overrule values set in the config file
 
 For a complete example of configuration options see the [example](#Example-configuration-file) at the bottom
@@ -52,18 +52,41 @@ s3cmd -c PATH_TO_S3CONF_FILE ls s3://BUCKET-NAME/*INDEX-NAME
 
 ### Backing up a database
 
+#### Dump
+
 * backup will be stored in S3 in the format of `YYYYMMDDhhmmss-DBNAME.sqldump`
 
 ```cmd
 ./backup-svc --action pg_dump
 ```
 
+#### Pg_basebackup
+
+* backup will be stored in S3 in the format of `YYYYMMDDhhmmss-DBNAME.tar`
+
+```cmd
+docker container run --rm -i --name pg-backup --network=host $(docker build -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_basebackup
+```
+
 ### Restoring up a database
+
+#### Restare dump file
 
 * The target database must exist when restoring the data.
 
 ```cmd
 ./backup-svc --action pg_restore --name PG-DUMP-FILE
+```
+
+#### Restore from physical copy
+
+* The target database must exist when restoring the data.
+
+* The postgres data will be stored locally and during the redeployment postgres db must point to the folder `tmp/db-backup`
+
+
+```cmd
+docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name TAR-FILE
 ```
 
 ## MongoDB

--- a/compression.go
+++ b/compression.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func newCompressor(key []byte, w io.Writer) (io.WriteCloser, error) {
+func newCompressor(w io.Writer) (io.WriteCloser, error) {
 
 	zw := zlib.NewWriter(w)
 	_, err := zlib.NewWriterLevel(zw, zlib.BestCompression)
@@ -19,7 +19,7 @@ func newCompressor(key []byte, w io.Writer) (io.WriteCloser, error) {
 	return zw, nil
 }
 
-func newDecompressor(key []byte, r io.Reader) (io.ReadCloser, error) {
+func newDecompressor(r io.Reader) (io.ReadCloser, error) {
 
 	zr, err := zlib.NewReader(r)
 	if err != nil {

--- a/dev_tools/Dockerfile-backup
+++ b/dev_tools/Dockerfile-backup
@@ -1,0 +1,19 @@
+FROM golang:1.16-alpine
+
+WORKDIR /source
+
+COPY go.mod ./
+COPY go.sum ./
+
+RUN go mod download
+
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -o /bin/sda-backup
+
+FROM postgres:13-alpine
+ENV POSTGRES_PASSWORD random-pw
+COPY dev_tools/config_postgres.yaml ./
+COPY dev_tools/certs ./dev_tools/certs
+COPY dev_tools/keys ./dev_tools/keys
+COPY --from=0 /bin/sda-backup /bin/sda-backup
+ENV CONFIGFILE="../config_postgres.yaml"

--- a/dev_tools/Dockerfile-backup
+++ b/dev_tools/Dockerfile-backup
@@ -1,5 +1,4 @@
 FROM golang:1.16-alpine
-
 WORKDIR /source
 
 COPY go.mod ./
@@ -11,9 +10,13 @@ COPY *.go ./
 RUN CGO_ENABLED=0 go build -o /bin/sda-backup
 
 FROM postgres:13-alpine
+ARG USER_ID
+ARG GROUP_ID
+
 ENV POSTGRES_PASSWORD random-pw
 COPY dev_tools/config_postgres.yaml ./
 COPY dev_tools/certs ./dev_tools/certs
 COPY dev_tools/keys ./dev_tools/keys
 COPY --from=0 /bin/sda-backup /bin/sda-backup
 ENV CONFIGFILE="../config_postgres.yaml"
+ENV UID=$USER_ID

--- a/dev_tools/Dockerfile-backup
+++ b/dev_tools/Dockerfile-backup
@@ -10,13 +10,8 @@ COPY *.go ./
 RUN CGO_ENABLED=0 go build -o /bin/sda-backup
 
 FROM postgres:13-alpine
-ARG USER_ID
-ARG GROUP_ID
-
-ENV POSTGRES_PASSWORD random-pw
 COPY dev_tools/config_postgres.yaml ./
 COPY dev_tools/certs ./dev_tools/certs
 COPY dev_tools/keys ./dev_tools/keys
 COPY --from=0 /bin/sda-backup /bin/sda-backup
 ENV CONFIGFILE="../config_postgres.yaml"
-ENV UID=$USER_ID

--- a/dev_tools/docker-compose.yml
+++ b/dev_tools/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       timeout: 20s
       retries: 3
     restart: always
-    image: postgres:11.2-alpine
+    image: postgres:13-alpine
     ports:
       - "5432:5432"
     volumes:

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -57,5 +57,15 @@ if [ "$USER" != "dummy" ]; then
     exit 1
 fi
 
+# Insert new test data and check if the database is writable
+docker exec db psql -U postgres -d test -c "INSERT INTO local_ega.main(submission_file_path,submission_user,submission_file_extension,status,encryption_method) VALUES('new-test.c4gh','new-dummy','c4gh','INIT','CRYPT4GH');"
+
+USER=$(docker exec db psql -U postgres -d test -tA -c "select submission_user from local_ega.main where submission_file_path = 'new-test.c4gh';")
+
+if [ "$USER" != "new-dummy" ]; then
+    echo "Expected to get user 'dummy' but got '$USER'"
+    exit 1
+fi
+
 # Remove the local folder
 docker volume rm restore

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -6,18 +6,31 @@ docker exec db psql -U postgres -d test -c "INSERT INTO local_ega.main(submissio
 # Build, run and execute the pg_basebackup action
 docker container run --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q -t backup .) /bin/sda-backup --action pg_basebackup
 
-# Find the name of the copy in the S3
+# Find the name of the copy in the S3 and check the length
 DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".tar" | cut -d '/' -f4)
+DBCOPYLENGTH=`echo -n "$DBCOPY" | wc -m`
 
-# Checks if the backup image exists locally from the previous step, if not creates the image
-# Then gets the physical copy of the database from the S3
+# Find the name of the backup image created in the previous step and check the length
 IMAGENAME=$(docker images -q backup)
 NAMELENGTH=`echo -n "$IMAGENAME" | wc -m`
 
-if [ $NAMELENGTH = 0 ]; then
-    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+# Make sure that the image and the db copy exist before moving on
+if [ $NAMELENGTH = 0 ] || [ $DBCOPYLENGTH = 0 ]; then
+    echo "the image or the db copy is missing"
+    exit 1
+# Get the db copy from S3
 else
     docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+fi
+
+# Drop the database to make sure that the test entry is not there anymore
+docker exec db psql -U postgres -d postgres -c "DROP DATABASE test;"
+
+# Check that the database is not there anymore
+USER=$(docker exec db psql -U postgres -d test -tA -c "select submission_user from local_ega.main where submission_file_path = 'test.c4gh';") > /dev/null 2>&1
+if [ "$USER" = "dummy" ]; then
+    echo "Failed to drop database"
+    exit 1
 fi
 
 # Remove everything from the db

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -20,7 +20,7 @@ if [ $NAMELENGTH = 0 ] || [ $DBCOPYLENGTH = 0 ]; then
     exit 1
 # Get the db copy from S3
 else
-    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_db-unpack --name "$DBCOPY"
 fi
 
 # Drop the database to make sure that the test entry is not there anymore

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+docker exec db psql -U postgres -d test -c "INSERT INTO local_ega.main(submission_file_path,submission_user,submission_file_extension,status,encryption_method) VALUES('test.c4gh','dummy','c4gh','INIT','CRYPT4GH');"
+
+docker container run --rm -i --name pg-backup --network=host $(docker build -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_basebackup
+
+DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".tar" | cut -d '/' -f4)
+
+docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+
+docker exec -i db /bin/sh -c "rm -r data/pgdata"
+
+docker cp tmp/db-backup/ db:data/pgdata
+
+# Check when the container restarts
+docker events --filter 'container=db'  | while read event
+do
+    check_event=$(echo $event | awk '{print $3}')
+    if [ "$check_event" = "start" ]; then
+        echo "container restarted"
+        break
+    fi
+done;
+
+
+USER=$(docker exec db psql -U postgres -d test -tA -c "select submission_user from local_ega.main where submission_file_path = 'test.c4gh';")
+
+if [ "$USER" != "dummy" ]; then
+    echo "Expected to get user 'dummy' but got '$USER'"
+    exit 1
+fi
+
+rm -r tmp

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -36,7 +36,7 @@ do
     fi
 done;
 
-# Find the user in tha db
+# Find the user in the db
 USER=$(docker exec db psql -U postgres -d test -tA -c "select submission_user from local_ega.main where submission_file_path = 'test.c4gh';")
 
 # Check if the user is the expected one

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -24,21 +24,11 @@ fi
 docker volume create restore
 docker container run --rm -i --name pg-backup --network=host -v restore:/home backup /bin/sda-backup --action pg_db-unpack --name "$DBCOPY"
 
-# Remove everything from the db
-docker exec -i db /bin/sh -c "rm -r data/pgdata"
-
-# Check that the pgdata are not there anymore
-USER=$(docker exec db psql -U postgres -d skata -tA -c "select submission_user from local_ega.main where submission_file_path = 'test.c4gh';") 2>/dev/null
-if [ "$USER" = "dummy" ]; then
-    echo "Failed to drop database"
-    exit 1
-fi
-
 # Stop the running db
 docker stop db
 
 # Add the physical copy in the db container
-docker run --rm -v restore:/pg-backup -v dev_tools_pgData:/pg-data alpine cp -r /pg-backup/db-backup/ /pg-data/pgdata/
+docker run --rm -v restore:/pg-backup -v dev_tools_pgData:/pg-data alpine /bin/sh -c "rm -r data/pgdata && cp -r /pg-backup/db-backup/ /pg-data/pgdata/"
 
 # start the DB container
 docker start db

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -48,10 +48,10 @@ RETRY_TIMES=0
 until [ $(docker inspect --format "{{json .State.Health.Status }}" db) = "\"healthy\"" ]
 do
   echo "Waiting for container to become ready"
-  docker logs db | grep -i  "ERROR"
   RETRY_TIMES=$((RETRY_TIMES+1));
   echo $RETRY_TIMES
   if [ $RETRY_TIMES -eq 30 ]; then
+    docker logs db | grep -i  "ERROR"
     exit 1;
   fi
   sleep 10;

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 
+# Insert some test data in the db
 docker exec db psql -U postgres -d test -c "INSERT INTO local_ega.main(submission_file_path,submission_user,submission_file_extension,status,encryption_method) VALUES('test.c4gh','dummy','c4gh','INIT','CRYPT4GH');"
 
-docker container run --rm -i --name pg-backup --network=host $(docker build -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_basebackup
+# Build, run and execute the pg_basebackup action
+docker container run --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q -t backup .) /bin/sda-backup --action pg_basebackup
 
+# Find the name of the copy in the S3
 DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".tar" | cut -d '/' -f4)
 
-docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+# Checks if the backup image exists locally from the previou step, if not creates the image
+# Then gets the physical copy of the database from the S3
+IMAGENAME=$(docker images -q backup)
+NAMELENGTH=`echo -n "$IMAGENAME" | wc -m`
 
+if [ $NAMELENGTH = 0 ]; then
+    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host $(docker build --build-arg USER_ID=$(id -u) -f dev_tools/Dockerfile-backup -q .) /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+else
+    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_bb-restore --name "$DBCOPY"
+fi
+
+# Remove everything from the db
 docker exec -i db /bin/sh -c "rm -r data/pgdata"
 
+# Add the physical copy in the db container
 docker cp tmp/db-backup/ db:data/pgdata
 
 # Check when the container restarts
@@ -22,12 +36,14 @@ do
     fi
 done;
 
-
+# Find the user in tha db
 USER=$(docker exec db psql -U postgres -d test -tA -c "select submission_user from local_ega.main where submission_file_path = 'test.c4gh';")
 
+# Check if the user is the expected one
 if [ "$USER" != "dummy" ]; then
     echo "Expected to get user 'dummy' but got '$USER'"
     exit 1
 fi
 
+# Remove the local folder
 rm -r tmp

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -9,7 +9,7 @@ docker container run --rm -i --name pg-backup --network=host $(docker build --bu
 # Find the name of the copy in the S3
 DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".tar" | cut -d '/' -f4)
 
-# Checks if the backup image exists locally from the previou step, if not creates the image
+# Checks if the backup image exists locally from the previous step, if not creates the image
 # Then gets the physical copy of the database from the S3
 IMAGENAME=$(docker images -q backup)
 NAMELENGTH=`echo -n "$IMAGENAME" | wc -m`

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -18,10 +18,10 @@ NAMELENGTH=`echo -n "$IMAGENAME" | wc -m`
 if [ $NAMELENGTH = 0 ] || [ $DBCOPYLENGTH = 0 ]; then
     echo "the image or the db copy is missing"
     exit 1
-# Get the db copy from S3
-else
-    docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_db-unpack --name "$DBCOPY"
 fi
+
+# Get the db copy from S3
+docker container run -v $(pwd)/tmp:/home --rm -i --name pg-backup --network=host backup /bin/sda-backup --action pg_db-unpack --name "$DBCOPY"
 
 # Drop the database to make sure that the test entry is not there anymore
 docker exec db psql -U postgres -d postgres -c "DROP DATABASE test;"

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -27,8 +27,8 @@ docker container run --rm -i --name pg-backup --network=host -v restore:/home ba
 # Stop the running db
 docker stop db
 
-# Add the physical copy in the db container
-docker run --rm -v restore:/pg-backup -v dev_tools_pgData:/pg-data alpine /bin/sh -c "rm -r data/pgdata && cp -r /pg-backup/db-backup/ /pg-data/pgdata/"
+# Delete pgdata and add the physical copy in the db container
+docker run --rm -v restore:/pg-backup -v dev_tools_pgData:/pg-data alpine /bin/sh -c "rm -r pg-data/pgdata && cp -r /pg-backup/db-backup/ /pg-data/pgdata/"
 
 # start the DB container
 docker start db

--- a/dev_tools/scripts/db_integrity_test.sh
+++ b/dev_tools/scripts/db_integrity_test.sh
@@ -7,7 +7,7 @@ docker exec db psql -U postgres -d test -c "INSERT INTO local_ega.main(submissio
 docker container run --rm -i --name pg-backup --network=host $(docker build -f dev_tools/Dockerfile-backup -q -t backup .) /bin/sda-backup --action pg_basebackup
 
 # Find the name of the copy in the S3 and check the length
-DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".tar" | cut -d '/' -f4)
+DBCOPY=$(s3cmd -c dev_tools/s3conf ls s3://dumps/ | grep ".enc" | cut -d '/' -f4)
 DBCOPYLENGTH=`echo -n "$DBCOPY" | wc -m`
 
 # Find the name of the backup image created in the previous step and check the length

--- a/dev_tools/sql_files/repl_md5_conf.sh
+++ b/dev_tools/sql_files/repl_md5_conf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "host replication all all md5" >> /data/pgdata/pg_hba.conf

--- a/elastic.go
+++ b/elastic.go
@@ -196,7 +196,7 @@ func (es esClient) backupDocuments(sb *s3Backend, keyPath, indexGlob string) err
 			return err
 		}
 
-		c, err := newCompressor(key, e)
+		c, err := newCompressor(e)
 
 		if err != nil {
 			log.Errorf("Could not initialize encryptor: (%v)", err)
@@ -306,7 +306,7 @@ func (es *esClient) restoreDocuments(sb *s3Backend, keyPath, fileName string) er
 		log.Error("Could not initialise decryptor", err)
 		return err
 	}
-	d, err := newDecompressor(key, r)
+	d, err := newDecompressor(r)
 	if err != nil {
 		log.Error("Could not initialise decompressor", err)
 		return err

--- a/main.go
+++ b/main.go
@@ -65,5 +65,10 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	case "pg_basebackup":
+		err := pg.basebackup(*sb, conf.keyPath)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -70,8 +70,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-	case "pg_bb-restore":
-		err := pg.baseBackupRestore(*sb, conf.keyPath, flags.name)
+	case "pg_db-unpack":
+		err := pg.baseBackupUnpack(*sb, conf.keyPath, flags.name)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -70,5 +70,10 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	case "pg_bb-restore":
+		err := pg.baseBackupRestore(*sb, conf.keyPath, flags.name)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/mongo.go
+++ b/mongo.go
@@ -58,7 +58,7 @@ func (mongo mongoConfig) dump(sb s3Backend, keyPath, database string) error {
 		return err
 	}
 
-	c, err := newCompressor(key, e)
+	c, err := newCompressor(e)
 	if err != nil {
 		log.Errorf("Could not initialize compressor: (%v)", err)
 		return err
@@ -92,7 +92,7 @@ func (mongo mongoConfig) restore(sb s3Backend, keyPath, archive string) error {
 		log.Error("Could not initialise decryptor", err)
 		return err
 	}
-	d, err := newDecompressor(key, r)
+	d, err := newDecompressor(r)
 	if err != nil {
 		log.Error("Could not initialise decompressor", err)
 		return err

--- a/postgres.go
+++ b/postgres.go
@@ -165,12 +165,12 @@ func (db DBConf) dump(sb s3Backend, keyPath string) error {
 	return nil
 }
 
-// Basebackuprestore function:
+// BasebackupUnpack function:
 // - gets the key to decrypt the pg_data
 // - decrypts and decompress the data
 // - untar the data
 // - puts the db copy in the running container
-func (db DBConf) baseBackupRestore(sb s3Backend, keyPath, backupTar string) error {
+func (db DBConf) baseBackupUnpack(sb s3Backend, keyPath, backupTar string) error {
 	localTar, err := os.Create("/home/backup.tar")
 	if err != nil {
 		log.Errorf("Error in creating file: %v", err)

--- a/postgres.go
+++ b/postgres.go
@@ -71,7 +71,14 @@ func (db DBConf) basebackup(sb s3Backend, keyPath string) error {
 		return err
 	}
 
-	c, err := newCompressor(wr)
+	key := getKey(keyPath)
+	e, err := newEncryptor(key, wr)
+	if err != nil {
+		log.Errorf("Could not initialize encryptor: (%v)", err)
+		return err
+	}
+
+	c, err := newCompressor(e)
 	if err != nil {
 		log.Errorf("Could not initialize compressor: (%v)", err)
 		return err
@@ -164,7 +171,14 @@ func (db DBConf) baseBackupRestore(sb s3Backend, keyPath, backupTar string) erro
 	}
 	defer fr.Close()
 
-	d, err := newDecompressor(fr)
+	key := getKey(keyPath)
+	r, err := newDecryptor(key, fr)
+	if err != nil {
+		log.Error("Could not initialise decryptor", err)
+		return err
+	}
+
+	d, err := newDecompressor(r)
 	if err != nil {
 		log.Errorf("Could not initialise decompressor: %v", err)
 		return err

--- a/postgres.go
+++ b/postgres.go
@@ -32,8 +32,8 @@ type DBConf struct {
 // - gets an identical copy of the pg database (pg_data)
 // - verifies the backup
 // - tars the copy
-// - gets the key and encrypts the tar file
 // - compresses the encrypted file
+// - gets the key and encrypts the tar file
 // - puts the encrypted and compressed file in S3
 func (db DBConf) basebackup(sb s3Backend, keyPath string) error {
 	today := time.Now().Format("20060102150405")

--- a/postgres.go
+++ b/postgres.go
@@ -213,6 +213,7 @@ func (db DBConf) baseBackupRestore(sb s3Backend, keyPath, backupTar string) erro
 		return err
 	}
 
+	// Change folder owner in order to have access to the folder locally
 	uID := viper.GetString("uid")
 	cmd = exec.Command("chown", "-R", uID, "/home")
 	cmd.Stderr = &errMsg

--- a/postgres.go
+++ b/postgres.go
@@ -69,7 +69,7 @@ func (db DBConf) basebackup(sb s3Backend, keyPath string) error {
 		return err
 	}
 
-	fileName := today + "-" + db.database + ".tar"
+	fileName := today + "-" + db.database + ".enc"
 	wg := sync.WaitGroup{}
 	wr, err := sb.NewFileWriter(fileName, &wg)
 	if err != nil {

--- a/postgres.go
+++ b/postgres.go
@@ -12,7 +12,6 @@ import (
 
 	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // DBConf stores information about the database backend
@@ -205,17 +204,6 @@ func (db DBConf) baseBackupUnpack(sb s3Backend, keyPath, backupTar string) error
 
 	cmd := exec.Command("tar", "-xvf", "/home/backup.tar", "--directory", "/home/")
 	var errMsg bytes.Buffer
-	cmd.Stderr = &errMsg
-
-	err = cmd.Run()
-	if err != nil {
-		log.Errorf(errMsg.String())
-		return err
-	}
-
-	// Change folder owner in order to have access to the folder locally
-	uID := viper.GetString("uid")
-	cmd = exec.Command("chown", "-R", uID, "/home")
 	cmd.Stderr = &errMsg
 
 	err = cmd.Run()

--- a/postgres.go
+++ b/postgres.go
@@ -28,6 +28,13 @@ type DBConf struct {
 	clientKey  string
 }
 
+// Basebackup function:
+// - gets an identical copy of the pg database (pg_data)
+// - verifies the backup
+// - tars the copy
+// - gets the key and encrypts the tar file
+// - compresses the encrypted file
+// - puts the encrypted and compressed file in S3
 func (db DBConf) basebackup(sb s3Backend, keyPath string) error {
 	today := time.Now().Format("20060102150405")
 	destDir := "db-backup"
@@ -158,6 +165,11 @@ func (db DBConf) dump(sb s3Backend, keyPath string) error {
 	return nil
 }
 
+// Basebackuprestore function:
+// - gets the key to decrypt the pg_data
+// - decrypts and decompress the data
+// - untar the data
+// - puts the db copy in the running container
 func (db DBConf) baseBackupRestore(sb s3Backend, keyPath, backupTar string) error {
 	localTar, err := os.Create("/home/backup.tar")
 	if err != nil {

--- a/postgres.go
+++ b/postgres.go
@@ -125,7 +125,7 @@ func (db DBConf) dump(sb s3Backend, keyPath string) error {
 		return err
 	}
 
-	c, err := newCompressor(key, e)
+	c, err := newCompressor(e)
 	if err != nil {
 		log.Errorf("Could not initialize compressor: (%v)", err)
 		return err
@@ -201,7 +201,7 @@ func (db DBConf) restore(sb s3Backend, keyPath, sqlDump string) error {
 		log.Error("Could not initialise decryptor", err)
 		return err
 	}
-	d, err := newDecompressor(key, r)
+	d, err := newDecompressor(r)
 	if err != nil {
 		log.Error("Could not initialise decompressor", err)
 		return err


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!-- IMPORTANT -->
<!-- This will bump the patch number on each PR merge unless the title contains #none. -->
<!-- In order to bump the major or minor version add #major or #minor to the PR title. -->



### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
With this PR during the postgres backup, the integrity of the database is checked as well. When this kind of backup is executed (pg_basebackup) then it runs through a container, it is connected to the database, gets the physical copy of the postgres database and puts it locally in the container. Next step is to check the database integrity where the db copy should not be compressed (that is why in the previous step the db copy is stored uncompressed). After the check, the whole copy is converted to a tar file, in order to have only one file for the next step which is the compression of the tar, then it is encrypted and placed in the S3 bucket. 
For restoring (pg_bb-restore), again it runs in a container, the reverse procedure is followed: get the file from the S3 in the container, decrypt, decompress and untar the copy. The container that is created for restoring has a mounted volume in order to get the physical db copy locally.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

<!-- For database schema changes, be extra mindful that any changes done in -->
<!-- the base schema setup is reflected in the changs performed by migrations  -->
<!-- scripts -->
1) Add replication md5 in pg_hba.conf (necessary for the pg_basebackup).
2) Upgrade to postgres 13 because db integrity is not available in older versions.
3) Add the options pg_basebackup and pg_bb-restore in main.
4) A dockerfile is added in order to create a container and run the pg_basebackup and pg_bb-restore from this container. This had to be done because I was running into problems with compatibility of postgres v13.
5) An integration test script is added (db_integrity_test.sh) for the db integrity.
6) The key argument removed from compressor and decompressor functions because there was no reason for being there.
7) Update the readme with instructions of the new arguments.


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Instructions for running the pg_basebackup and restore from that have been added. The commands include containers for running both actions (faced some compatibility issues with the version 13 of postgres).

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
