### PR TITLE
update to go 1.22

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build backup-svc container
       run: docker build -t nbisweden/sda-backup:test .

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: install s3cmd
       run: pip3 install s3cmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-alpine3.17
+FROM golang:1.22-alpine3.18
 COPY . .
 ENV GO111MODULE=on
 ENV GOPATH=$PWD

--- a/dev_tools/Dockerfile-backup
+++ b/dev_tools/Dockerfile-backup
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine3.18
 WORKDIR /source
 
 COPY go.mod ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/aws/aws-sdk-go v1.53.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.53.1


### PR DESCRIPTION
### Related issues:
New crypt4gh version requires go 1.22: #547 