### PR TITLE
docker-compose command is deprecated

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -38,7 +38,7 @@ jobs:
       run: bash ./dev_tools/scripts/make_keys.sh
 
     - name: Start virtual infrastructure
-      run: docker-compose -f ./dev_tools/docker-compose.yml up -d --force-recreate
+      run: docker compose -f ./dev_tools/docker-compose.yml up -d --force-recreate
 
     - name: Wait for containers to start
       run: bash ./dev_tools/scripts/readiness.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
       run: bash ./dev_tools/scripts/make_keys.sh
 
     - name: Start virtual infrastructure
-      run: docker-compose -f ./dev_tools/docker-compose.yml up -d --force-recreate --build
+      run: docker compose -f ./dev_tools/docker-compose.yml up -d --force-recreate --build
 
     - name: Wait for containers to start
       run: bash ./dev_tools/scripts/readiness.sh


### PR DESCRIPTION
### Describe the pull request:
- [x] Bug fix


### Pull request long description:
Fix for tests, see #565 #566 #567 

### Changes made:
Use `docker compose` instead of `docker-compose`
